### PR TITLE
Fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 - 👋 Hi, I’m Prajeeth Emanuel @emanuel1025
 - 👀 I’m interested in Distributed Systems and Data-Intensive Systems
-- 🌱 I’m currently learning Systems Modeling and Performance Analysis @ [PACE Lab](http://www.pace.cs.stonybrook.edu/)
+- 🌱 I’m currently learning Systems Modeling and Performance Analysis @ [PACE Lab](https://www.pace.cs.stonybrook.edu/)
 - 💞️ I’m looking to collaborate on optimizing large scale, high-performance data processing systems (batch and/or streaming)
-- 📫 How to reach me [Linkedin](https://www.linkedin.com/in/prajeeth-emanuel-315b1684/) / pvethanayaga@cs.stonybrook.edu
+- 📫 How to reach me [LinkedIn](https://www.linkedin.com/in/prajeeth-emanuel-315b1684/) / pvethanayaga@cs.stonybrook.edu
 - 🐕 I was previously a SWE [@Apple](https://www.apple.com/maps/) and completed my undergraduate in CS from [IIIT Hyderabad](https://www.iiit.ac.in/)
 
 <!---


### PR DESCRIPTION
## Summary
- fix outdated HTTP link to PACE Lab
- correct "Linkedin" branding

## Testing
- `curl -I https://www.pace.cs.stonybrook.edu/ 2>&1 | head`

------
https://chatgpt.com/codex/tasks/task_e_687d4a91d96883269b8b8fddaf60b782